### PR TITLE
Add disable_proxy Option for Kubernetes Forwards

### DIFF
--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -94,7 +94,7 @@ type Forward struct {
 // IsProxified indicates if the current forward rule will use the proxy
 func (f *Forward) IsProxified() bool {
 	if value, ok := ProxifiedForwarders[f.Type]; ok && value {
-		return true
+		return !f.Values.DisableProxy
 	}
 
 	return false
@@ -107,6 +107,7 @@ type ForwardValues struct {
 	Labels        map[string]string `yaml:"labels"`
 	Hostname      string            `yaml:"hostname"`
 	ProxyHostname string            `yaml:"proxy_hostname"`
+	DisableProxy  bool              `yaml:"disable_proxy"`
 	Ports         []string          `yaml:"ports"`
 	Remote        string            `yaml:"remote"`
 	Args          []string          `yaml:"args"`

--- a/pkg/config/model_test.go
+++ b/pkg/config/model_test.go
@@ -36,7 +36,7 @@ func TestApplicationGetPathWhenGoPath(t *testing.T) {
 	assert.Equal(t, "/tmp/gopath/src/fake.github.com/user/repository", path)
 }
 
-func TestForwardIsProxified(t *testing.T) {
+func TestForwardTypeIsProxified(t *testing.T) {
 	// Given
 	testCases := []struct {
 		forwardType string
@@ -52,6 +52,31 @@ func TestForwardIsProxified(t *testing.T) {
 	for _, testCase := range testCases {
 		forward := Forward{
 			Type: testCase.forwardType,
+		}
+
+		assert.Equal(t, testCase.expected, forward.IsProxified())
+	}
+}
+
+func TestForwardConfigIsProxified(t *testing.T) {
+	// Given
+	testCases := []struct {
+		forwardType  string
+		disableProxy bool
+		expected     bool
+	}{
+		{forwardType: ForwarderKubernetes, disableProxy: false, expected: true},
+		{forwardType: ForwarderKubernetes, disableProxy: true, expected: false},
+	}
+
+	// When - Then
+	for _, testCase := range testCases {
+		values := ForwardValues{
+			DisableProxy: testCase.disableProxy,
+		}
+		forward := Forward{
+			Type:   testCase.forwardType,
+			Values: values,
 		}
 
 		assert.Equal(t, testCase.expected, forward.IsProxified())

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -138,7 +138,11 @@ func (f *Forwarder) forward(forward *config.Forward, wg *sync.WaitGroup) {
 	switch forward.Type {
 	// Kubernetes local port-forward: give proxy port as local port and forwarded port, use proxy
 	case config.ForwarderKubernetes:
-		forwarder, err := kubernetes.NewForwarder(f.view, forward.Type, forward.Name, values.Context, values.Namespace, proxifiedPorts, values.Labels)
+		forwardPorts := values.Ports
+		if forward.IsProxified() {
+			forwardPorts = proxifiedPorts
+		}
+		forwarder, err := kubernetes.NewForwarder(f.view, forward.Type, forward.Name, values.Context, values.Namespace, forwardPorts, values.Labels)
 		if err != nil {
 			f.view.Writef("❌  %s\n", err.Error())
 			return


### PR DESCRIPTION
Hello! 

We're using Monday for a local development tool, and we need the option to run kubernetes port forwards to `localhost` on the port provided in the config, without any proxying. I've added the changes necessary to disable proxying for kubernetes type forwards. 

