### PR TITLE
Fixed remote ssh forward not being applied

### DIFF
--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -192,8 +192,9 @@ func (f *Forwarder) forward(forward *config.Forward, wg *sync.WaitGroup) {
 
 	// SSH remote forward: give local port and forwarded port, do not proxy
 	case config.ForwarderSSHRemote:
-		for _, proxyForward := range proxyForwards {
-			forwarder, err := ssh.NewForwarder(f.view, forward.Type, values, proxyForward.LocalPort, proxyForward.ForwardPort)
+		for _, ports := range values.Ports {
+			localPort, forwardPort := splitLocalAndForwardPorts(ports)
+			forwarder, err := ssh.NewForwarder(f.view, forward.Type, values, localPort, forwardPort)
 			if err != nil {
 				f.view.Writef("❌  %s\n", err.Error())
 				return


### PR DESCRIPTION
Hi! First of all thanks for the great project 👍 

When I tried to set up remote ssh port forwarding it seems like it was just ignored.
After looking at the code it looks like either I do not fully understand how it should be configured and work, or there is a bug.

In `pkg/forwarder/forwarder.go` for `config.ForwarderSSHRemote` we skip setting up of `proxyForward` because of it is not `forward.IsProxified()` witch seems fine.
But later we range on it `for _, proxyForward := range proxyForwards {`, but its empty. And as a result, we do not get any forwarders for remote-ssh.

I hope I understand the code well enough to do a reasonable fix. Looking forward to your feedback.