### PR TITLE
Added a run section and hamonize way commands are launched

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ Here is an example of a local application:
       - go build -o ./build/graphql-app cmd/ # Here, just build the Go application
     env:
       CGO_ENABLED: on
-  executable: ./build/graphql-app # Then, run it using the executable
-  env: # Optional, in case you want to specify some environment variables for this app
-    HTTP_PORT: 8005
-  env_file: "github.com/eko/graphql/.env" # Or via a .env file also
+  run:
+    command: ./build/graphql-app # Then, run it using this built binary
+    env: # Optional, in case you want to specify some environment variables for this app
+      HTTP_PORT: 8005
+    env_file: "github.com/eko/graphql/.env" # Or via a .env file also
 ```
 
 Then, imagine this GraphQL instance needs to call a user-api but we want to forward it from a Kubernetes environment, we will define it as follows.

--- a/example.yaml
+++ b/example.yaml
@@ -21,7 +21,7 @@ watch: # Optional
 
 <: &graphql-local
   name: graphql
-  path: github.com/eko/graphql # Will find in GOPATH (as executable is "go")
+  path: github.com/eko/graphql # Will find in GOPATH
   watch: true # Default: false (do not watch directory)
   hostname: graphql.svc.local # Optional, in case you want to map a specific hostname with a single IP address
   setup: # Optional, in case you want to setup the project first if directory does not exists
@@ -37,24 +37,17 @@ watch: # Optional
       - docker build -t graphql-image .
     env:
       DOCKER_BUILDKIT: 1
-  executable: docker
-  args:
-    - run
-    - --rm
-    - --name
-    - graphql
-    - graphql-image
-  env: # Optional, in case you want to specify some environment variables for this app
-    HTTP_PORT: 8005
-  env_file: "github.com/eko/graphql/.env" # Optional, in case you want to specify some environment variables from a file
-  stop_executable: docker
-  stop_args:
-    - stop
-    - graphql
+  run:
+    command: docker run --rm --name graphql --network=host graphql-image
+    env: # Optional, in case you want to specify some environment variables for this app
+      HTTP_PORT: 8005
+    env_file: "github.com/eko/graphql/.env" # Optional, in case you want to specify some environment variables from a file
+    stop_commands:
+      - docker stop graphql
 
 <: &grpc-api-local
   name: grpc-api
-  path: github.com/eko/grpc-api # Will find in GOPATH (as executable is "go")
+  path: github.com/eko/grpc-api # Will find in GOPATH
   watch: true # Default: false (do not watch directory)
   hostname: grpc-api.svc.local # Optional, in case you want to map a specific hostname with a single IP address
   setup: # Optional, in case you want to setup the project first if directory does not exists
@@ -64,27 +57,20 @@ watch: # Optional
     env: # Also optional, in case you need to specify some environment variables
       GOPRIVATE=*.acme.tld
     env_file: ~/my/project/.env # Or, via an environment file...
-  executable: go
-  args:
-    - run
-    - main.go
-  env: # Optional, in case you want to specify some environment variables for this app
-    GRPC_PORT: 8006
-  env_file: "github.com/eko/grpc-api/.env" # Optional, in case you want to specify some environment variables from a file
+  run:
+    command: go run main.go
+    env: # Optional, in case you want to specify some environment variables for this app
+      GRPC_PORT: 8006
+    env_file: "github.com/eko/grpc-api/.env" # Optional, in case you want to specify some environment variables from a file
 
 <: &elasticsearch-local
   name: elasticsearch
   path: /Users/vincent/dev/docker
   watch: true # Default: false (do not watch directory)
-  executable: docker
-  args:
-    - start
-    - -i
-    - elastic
-  stop_executable: docker # Optional, but useful for stopping containers for instance
-  stop_args: # Optional
-    - stop
-    - elastic
+  run:
+    command: docker start -i elastic
+    stop_commands:
+      - docker stop elastic
 
 # Kubernetes forwards
 

--- a/pkg/build/command/builder.go
+++ b/pkg/build/command/builder.go
@@ -39,7 +39,7 @@ func Build(application *config.Application, view ui.View, conf *config.GlobalBui
 	}
 
 	helper.AddEnvVariables(cmd, envs)
-	if err := helper.AddEnvVariablesFromFile(cmd, application.GetEnvFile()); err != nil {
+	if err := helper.AddEnvVariablesFromFile(cmd, build.GetEnvFile()); err != nil {
 		return err
 	}
 

--- a/pkg/config/model_test.go
+++ b/pkg/config/model_test.go
@@ -9,15 +9,18 @@ import (
 
 func TestApplicationGetPathWhenAbsoluePath(t *testing.T) {
 	// Given
+	tmpDirectory := os.TempDir()
+	defer os.Remove(tmpDirectory)
+
 	application := Application{
-		Path: "/tmp/this/is/a/test",
+		Path: tmpDirectory,
 	}
 
 	// When
 	path := application.GetPath()
 
 	// Path
-	assert.Equal(t, "/tmp/this/is/a/test", path)
+	assert.Equal(t, tmpDirectory, path)
 }
 
 func TestApplicationGetPathWhenGoPath(t *testing.T) {
@@ -25,8 +28,7 @@ func TestApplicationGetPathWhenGoPath(t *testing.T) {
 	os.Setenv("GOPATH", "/tmp/gopath")
 
 	application := Application{
-		Executable: "go",
-		Path:       "fake.github.com/user/repository",
+		Path: "fake.github.com/user/repository",
 	}
 
 	// When

--- a/pkg/forward/forwarder.go
+++ b/pkg/forward/forwarder.go
@@ -226,7 +226,7 @@ func (f *forwarder) forward(forward *config.Forward, wg *sync.WaitGroup) {
 }
 
 func (f *forwarder) checkForwardEnvironment(forward *config.Forward) error {
-	// Check executable is already managed
+	// Check forward type is already managed
 	if result, ok := config.AvailableForwarders[forward.Type]; !ok || !result {
 		return fmt.Errorf("The '%s' specified forward type named '%s' is not managed actually", forward.Type, forward.Name)
 	}

--- a/pkg/helper/cmd.go
+++ b/pkg/helper/cmd.go
@@ -20,9 +20,15 @@ func BuildCmd(commandsList []string, path string, stdout, stderr *log.Streamer) 
 	cmd := exec.Command("/bin/sh", "-c", strings.Replace(commands, "'", "\\'", -1))
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Dir = path
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
 	cmd.Env = os.Environ()
+
+	if stdout != nil {
+		cmd.Stdout = stdout
+	}
+
+	if stderr != nil {
+		cmd.Stderr = stderr
+	}
 
 	return cmd
 }

--- a/pkg/helper/env_test.go
+++ b/pkg/helper/env_test.go
@@ -16,7 +16,7 @@ func TestAddEnvVariables(t *testing.T) {
 	cmd := &exec.Cmd{}
 
 	// When
-	AddEnvVariables(cmd, application.Env)
+	AddEnvVariables(cmd, application.Run.Env)
 
 	// Then
 	assert.Contains(t, cmd.Env, "MY_ENVVAR_1=value")
@@ -30,7 +30,7 @@ func TestAddEnvVariablesFromFile(t *testing.T) {
 	cmd := &exec.Cmd{}
 
 	// When
-	AddEnvVariablesFromFile(cmd, application.EnvFile)
+	AddEnvVariablesFromFile(cmd, application.Run.EnvFile)
 
 	// Then
 	assert.Contains(t, cmd.Env, "MY_ENVFILE_VAR_1=this is ok")
@@ -42,19 +42,15 @@ func getMockedApplication() *config.Application {
 	dir, _ := os.Getwd()
 
 	return &config.Application{
-		Name:       "test-app",
-		Path:       "/",
-		Executable: "echo",
-		Args: []string{
-			"OK",
-			"Arguments",
-			"Seems",
-			"-to=work",
+		Name: "test-app",
+		Path: "/",
+		Run: &config.Run{
+			Command: "echo OK Arguments Seems -to=work",
+			Env: map[string]string{
+				"MY_ENVVAR_1": "value",
+				"MY_ENVVAR_2": "My custom second value",
+			},
+			EnvFile: dir + "/../../internal/tests/runner/test.env",
 		},
-		Env: map[string]string{
-			"MY_ENVVAR_1": "value",
-			"MY_ENVVAR_2": "My custom second value",
-		},
-		EnvFile: dir + "/../../internal/tests/runner/test.env",
 	}
 }

--- a/pkg/run/runner_test.go
+++ b/pkg/run/runner_test.go
@@ -66,7 +66,7 @@ func TestRunAll(t *testing.T) {
 	// Check for application to be runned properly
 	if cmd, ok := runner.cmds["test-app"]; ok {
 		runCommand := strings.Replace(strings.Join(cmd.Args, " "), "echo <runner>", "runner", -1)
-		assert.Equal(t, "echo OK Arguments Seems -to=work", runCommand)
+		assert.Equal(t, "/bin/sh -c echo OK Arguments Seems -to=work", runCommand)
 	} else {
 		t.Fatal("Cannot retrieve just launched application command execution")
 	}
@@ -103,7 +103,7 @@ func TestStop(t *testing.T) {
 	// Then
 	if cmd, ok := runner.cmds["test-app"]; ok {
 		runCommand := strings.Replace(strings.Join(cmd.Args, " "), "echo <runner>", "runner", -1)
-		assert.Equal(t, "echo OK Arguments Seems -to=work", runCommand)
+		assert.Equal(t, "/bin/sh -c echo OK Arguments Seems -to=work", runCommand)
 
 		assert.True(t, cmd.ProcessState.Exited())
 	} else {
@@ -116,14 +116,10 @@ func getMockedProjectWithApplication() *config.Project {
 		Name: "My project name",
 		Applications: []*config.Application{
 			{
-				Name:       "test-app",
-				Path:       "/",
-				Executable: "echo",
-				Args: []string{
-					"OK",
-					"Arguments",
-					"Seems",
-					"-to=work",
+				Name: "test-app",
+				Path: "/",
+				Run: &config.Run{
+					Command: "echo OK Arguments Seems -to=work",
 				},
 			},
 		},

--- a/pkg/setup/setuper_test.go
+++ b/pkg/setup/setuper_test.go
@@ -69,14 +69,10 @@ func getMockedProjectWithApplication() *config.Project {
 		Name: "My project name",
 		Applications: []*config.Application{
 			{
-				Name:       "test-app",
-				Path:       "/",
-				Executable: "echo",
-				Args: []string{
-					"OK",
-					"Arguments",
-					"Seems",
-					"-to=work",
+				Name: "test-app",
+				Path: "/",
+				Run: &config.Run{
+					Command: "echo OK Arguments Seems -to=work",
 				},
 			},
 		},


### PR DESCRIPTION
When declaring a local application, previously you had to define:

```yaml
<: &graphql-local
  name: graphql
  path: $GOPATH/src/github.com/eko/graphql
  hostname: graphql.svc.local
  build:
    type: command
    commands:
      - go build -o ./build/graphql-app cmd/
  executable: ./build/graphql-app
  env:
    HTTP_PORT: 8005
  env_file: "github.com/eko/graphql/.env"
```

Now, this has been grouped under a `run` YAML section, such as `setup` and `build`:

```yaml
<: &graphql-local
  name: graphql
  path: $GOPATH/src/github.com/eko/graphql
  hostname: graphql.svc.local
  build:
    type: command
    commands:
      - go build -o ./build/graphql-app cmd/
  run:
    command: ./build/graphql-app
    env:
      HTTP_PORT: 8005
    env_file: "github.com/eko/graphql/.env"
```

Also, the way commands are launched has been harmonized by switching from the `executable` / `args` couple to `command`.