### PR TITLE
Rework network to allow IP generation range from 127.1.2.1 to 127.255.255.255

### DIFF
--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -3,6 +3,7 @@
 package proxy
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/eko/monday/pkg/hostfile"
@@ -29,7 +30,7 @@ func TestNewProxy(t *testing.T) {
 
 	assert.Len(t, p.ProxyForwards, 0)
 	assert.Equal(t, p.latestPort, "9400")
-	assert.Equal(t, p.ipLastByte, 1)
+	assert.Equal(t, p.ipLastByte, byte(1))
 }
 
 func TestAddProxyForward(t *testing.T) {
@@ -53,7 +54,7 @@ func TestAddProxyForward(t *testing.T) {
 	// Then
 	assert.Len(t, proxy.ProxyForwards, 1)
 	assert.Equal(t, proxy.latestPort, "9401")
-	assert.Equal(t, proxy.ipLastByte, 2)
+	assert.Equal(t, proxy.ipLastByte, byte(2))
 }
 
 func TestAddProxyForwardWhenMultiple(t *testing.T) {
@@ -120,5 +121,75 @@ func TestListen(t *testing.T) {
 
 	assert.Len(t, proxy.ProxyForwards, 1)
 	assert.Equal(t, proxy.latestPort, "9401")
-	assert.Equal(t, proxy.ipLastByte, 2)
+	assert.Equal(t, proxy.ipLastByte, byte(2))
+}
+
+func TestGetNextIPAddress(t *testing.T) {
+	testCases := []struct {
+		a byte
+		b byte
+		c byte
+		d byte
+
+		expectedA byte
+		expectedB byte
+		expectedC byte
+		expectedD byte
+	}{
+		{ // Case incrementing d
+			a: 127, b: 0, c: 0, d: 1,
+			expectedA: 127, expectedB: 0, expectedC: 0, expectedD: 2,
+		},
+		{ // Case incrementing d to last byte
+			a: 127, b: 0, c: 0, d: 254,
+			expectedA: 127, expectedB: 0, expectedC: 0, expectedD: 255,
+		},
+		{ // Case incrementing c and reset d to 1
+			a: 127, b: 0, c: 0, d: 255,
+			expectedA: 127, expectedB: 0, expectedC: 1, expectedD: 1,
+		},
+		{ // Case incrementing d to last byte
+			a: 127, b: 0, c: 1, d: 254,
+			expectedA: 127, expectedB: 0, expectedC: 1, expectedD: 255,
+		},
+		{ // Case incrementing c and reset d to 1
+			a: 127, b: 0, c: 1, d: 255,
+			expectedA: 127, expectedB: 0, expectedC: 2, expectedD: 1,
+		},
+		{ // Case incrementing d to last byte
+			a: 127, b: 0, c: 254, d: 254,
+			expectedA: 127, expectedB: 0, expectedC: 254, expectedD: 255,
+		},
+		{ // Case incrementing c and reset d to 1
+			a: 127, b: 0, c: 254, d: 255,
+			expectedA: 127, expectedB: 0, expectedC: 255, expectedD: 1,
+		},
+		{ // Case incrementing d to last byte when c is already on latest byte
+			a: 127, b: 0, c: 255, d: 254,
+			expectedA: 127, expectedB: 0, expectedC: 255, expectedD: 255,
+		},
+		{ // Case incrementing b and reset c and d to last byte
+			a: 127, b: 0, c: 255, d: 255,
+			expectedA: 127, expectedB: 1, expectedC: 1, expectedD: 1,
+		},
+		{ // Case incrementing d to last byte when b and c are already on latest byte
+			a: 127, b: 255, c: 255, d: 254,
+			expectedA: 127, expectedB: 255, expectedC: 255, expectedD: 255,
+		},
+		{ // Reached max level
+			a: 127, b: 255, c: 255, d: 255,
+			expectedA: 127, expectedB: 255, expectedC: 255, expectedD: 255,
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("Case %d", i), func(t *testing.T) {
+			a, b, c, d := getNextIPAddress(testCase.a, testCase.b, testCase.c, testCase.d)
+
+			assert.Equal(t, testCase.expectedA, a)
+			assert.Equal(t, testCase.expectedB, b)
+			assert.Equal(t, testCase.expectedC, c)
+			assert.Equal(t, testCase.expectedD, d)
+		})
+	}
 }


### PR DESCRIPTION
Before, monday had a limited IP range generation from `127.1.2.1` to `127.1.2.255`.

Now, we can generate much more IP / port couple in case you have to run/forward a larger number of application.
We can now cover from `127.1.2.1` to `127.255.255.255`.