### PR TITLE
Added a way to declare global local apps & forwards

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -118,6 +118,10 @@ func runProject(conf *config.Config, choice string) {
 		panic(err)
 	}
 
+	// Prepend global configurations
+	project.PrependApplications(conf.Applications)
+	project.PrependForwards(conf.Forwards)
+
 	// Initializes hosts file manager
 	hostfile, err := hostfile.NewClient()
 	if err != nil {

--- a/example.yaml
+++ b/example.yaml
@@ -162,6 +162,13 @@ watch: # Optional
     ports:
      - 9200:443
 
+# Optional, global local applications and/or forwards: these will be launched for every project you declare later
+local:
+  - *grafana-global # Not declared in this file for readability
+  - *prometheus-global # Not declared in this file for readability
+forward:
+  - *graylog-forward-kubernetes
+
 # Projects
 
 projects:

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -35,15 +35,22 @@ var (
 
 // Config represents the root configuration item
 type Config struct {
-	GoPath     string     `yaml:"gopath"`
-	KubeConfig string     `yaml:"kubeconfig"`
-	Projects   []*Project `yaml:"projects"`
-
 	// Global packages configurations
 	Build *GlobalBuild `yaml:"build"`
 	Run   *GlobalRun   `yaml:"run"`
 	Setup *GlobalSetup `yaml:"setup"`
 	Watch *GlobalWatch `yaml:"watch"`
+
+	// Global applications and forward list. If specified, these will always be launched with any project
+	Applications []*Application `yaml:"local"`
+	Forwards     []*Forward     `yaml:"forward"`
+
+	// Other global configuration values
+	GoPath     string `yaml:"gopath"`
+	KubeConfig string `yaml:"kubeconfig"`
+
+	// Projects
+	Projects []*Project `yaml:"projects"`
 }
 
 // GlobalBuild represents the global configuration values for the file builder component
@@ -71,6 +78,16 @@ type Project struct {
 	Name         string         `yaml:"name"`
 	Applications []*Application `yaml:"local"`
 	Forwards     []*Forward     `yaml:"forward"`
+}
+
+// PrependApplications prepends some global local applications to the current project.
+func (p *Project) PrependApplications(applications []*Application) {
+	p.Applications = append(applications, p.Applications...)
+}
+
+// PrependForwards prepends some global forwards to the current project.
+func (p *Project) PrependForwards(forwards []*Forward) {
+	p.Forwards = append(forwards, p.Forwards...)
 }
 
 // Application represents application information

--- a/pkg/config/model_test.go
+++ b/pkg/config/model_test.go
@@ -84,3 +84,63 @@ func TestForwardConfigIsProxified(t *testing.T) {
 		assert.Equal(t, testCase.expected, forward.IsProxified())
 	}
 }
+
+func TestProjectPrependApplications(t *testing.T) {
+	// Given
+	project := &Project{
+		Name: "My test project",
+		Applications: []*Application{
+			{Name: "My project app 1"},
+			{Name: "My project app 2"},
+		},
+	}
+
+	conf := &Config{
+		Applications: []*Application{
+			{Name: "My global app 1"},
+			{Name: "My global app 2"},
+		},
+		Projects: []*Project{project},
+	}
+
+	// When
+	project.PrependApplications(conf.Applications)
+
+	// Then
+	assert.Equal(t, []*Application{
+		{Name: "My global app 1"},
+		{Name: "My global app 2"},
+		{Name: "My project app 1"},
+		{Name: "My project app 2"},
+	}, project.Applications)
+}
+
+func TestProjectPrependForwards(t *testing.T) {
+	// Given
+	project := &Project{
+		Name: "My test project",
+		Forwards: []*Forward{
+			{Name: "My project forward 1"},
+			{Name: "My project forward 2"},
+		},
+	}
+
+	conf := &Config{
+		Forwards: []*Forward{
+			{Name: "My global forward 1"},
+			{Name: "My global forward 2"},
+		},
+		Projects: []*Project{project},
+	}
+
+	// When
+	project.PrependForwards(conf.Forwards)
+
+	// Then
+	assert.Equal(t, []*Forward{
+		{Name: "My global forward 1"},
+		{Name: "My global forward 2"},
+		{Name: "My project forward 1"},
+		{Name: "My project forward 2"},
+	}, project.Forwards)
+}


### PR DESCRIPTION
Allow declaration of "global" local applications and forwarded one.

So in case you have multiple projects, let's say 5 and you always want to run some tools when running your applications from monday, you will just declare them once at the root level of your YAML file, such as:

```yaml
local:
  - *grafana-global
  - *prometheus-global
forward:
  - *graylog-forward-kubernetes
```