### PR TITLE
Picking up first running pod instead of first unknown status pod from list

### DIFF
--- a/pkg/forward/kubernetes/forwarder.go
+++ b/pkg/forward/kubernetes/forwarder.go
@@ -190,12 +190,18 @@ func (f *Forwarder) forwardLocal(ctx context.Context, selector string) error {
 	}
 
 	var	runningPod apiv1.Pod
+	foundRunningPod := false
 
 	for _, pod := range pods.Items {
 		if isPodRunning(&pod) {
 			runningPod = pod
+			foundRunningPod = true
 			break
 		}
+	}
+
+	if !foundRunningPod {
+		return fmt.Errorf("No runnning pod available for selector '%s'", selector)
 	}
 	
 	request := f.restClient.Post().Resource("pods").Namespace(f.namespace).Name(runningPod.Name).SubResource("portforward")

--- a/pkg/forward/kubernetes/forwarder.go
+++ b/pkg/forward/kubernetes/forwarder.go
@@ -172,6 +172,10 @@ func (f *Forwarder) Stop(ctx context.Context) error {
 	return nil
 }
 
+func isPodRunning(pod *apiv1.Pod) bool {
+	return pod.Status.Phase == apiv1.PodRunning
+}
+
 func (f *Forwarder) forwardLocal(ctx context.Context, selector string) error {
 	pods, err := f.clientSet.CoreV1().Pods(f.namespace).List(
 		ctx,
@@ -185,9 +189,16 @@ func (f *Forwarder) forwardLocal(ctx context.Context, selector string) error {
 		return fmt.Errorf("No pod available for selector '%s': %v", selector, err)
 	}
 
-	pod := pods.Items[0]
+	var	runningPod apiv1.Pod
 
-	request := f.restClient.Post().Resource("pods").Namespace(f.namespace).Name(pod.Name).SubResource("portforward")
+	for _, pod := range pods.Items {
+		if isPodRunning(&pod) {
+			runningPod = pod
+			break
+		}
+	}
+	
+	request := f.restClient.Post().Resource("pods").Namespace(f.namespace).Name(runningPod.Name).SubResource("portforward")
 
 	url := url.URL{
 		Scheme:   request.URL().Scheme,
@@ -203,8 +214,8 @@ func (f *Forwarder) forwardLocal(ctx context.Context, selector string) error {
 
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", &url)
 
-	stdoutStream := log.NewStreamer(log.StdOut, pod.Name, f.view)
-	stderrStream := log.NewStreamer(log.StdErr, pod.Name, f.view)
+	stdoutStream := log.NewStreamer(log.StdOut, runningPod.Name, f.view)
+	stderrStream := log.NewStreamer(log.StdErr, runningPod.Name, f.view)
 
 	fw, err := portforward.New(dialer, f.ports, f.stopChannel, f.readyChannel, stdoutStream, stderrStream)
 	if err != nil {


### PR DESCRIPTION
It is sort of an edge case. 
This will only happen when you have multiple instances of the same service.

1) When you have low resources, one pod is in a running state, and the other is in a pending state. It tries to port forward to the pending state pod.
e.g. 

```
NAME        READY   STATUS    
myapp-adfa   1/1     Running  
myapp-rasf   0/1     Pending    <- connection to this
```

2) I had a service with replications. When I was doing a rolling upgrade with new deployment, I had set wrong secret that pod could not find and got stuck in the ContainerCreating state. So there were older pods in a running state instead of connecting to them, it was trying to connect the stuck pod.
e.g. 

```
NAME        READY   STATUS    
myapp-adfa   1/1     Running  
myapp-rasf   0/1     ContainerCreating    <- connection to this
```

```
error upgrading connection: unable to upgrade connection: pod not found ("myapp_dev")
👓  Forwarder: lost port-forward connection trying to reconnect...
error upgrading connection: unable to upgrade connection: pod not found ("myapp_dev")
👓  Forwarder: lost port-forward connection trying to reconnect...
```